### PR TITLE
Link to Bukkit 1.7.10.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,10 +22,10 @@
             <id>onarandombox</id>
             <url>http://repo.onarandombox.com/content/groups/public</url>
         </repository>
-        <!-- krinsoft Repository -->
+        <!-- sk89q Repository -->
         <repository>
-            <id>krinsoft</id>
-            <url>http://files.krinsoft.net:8085/nexus/content/groups/public</url>
+            <id>sk89q</id>
+            <url>http://maven.sk89q.com/repo</url>
         </repository>
     </repositories>
     <!-- Jenkins manager -->
@@ -119,7 +119,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.6.2-R0.1</version>
+            <version>1.7.10-R0.1-SNAPSHOT</version>
             <type>jar</type>
         </dependency>
         <!-- Multiverse-Core -->


### PR DESCRIPTION
Spigot 1.9 onwards removes the support for the deprecated version of `Server.getOnlinePlayers()`. This uses the non-deprecated version of `Server.getOnlinePlayers()` to correctly use the one that returns `Collection<? extends Player>` instead of `Player[]`.